### PR TITLE
Convert Expression Values For Easier Client Usage 

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -587,4 +587,10 @@ def main(inputValue):
     return allKarnaughMaps[0], variables, outputFromHLDEquiv[5]
 
 if __name__ == '__main__':
-    main();
+    if(len(sys.argv) >= 2):     
+        inputFile = sys.argv[1]
+        with open(inputFile) as currentFileReader:
+            inputValue = currentFileReader.readline()
+            main(inputValue)
+
+

--- a/backend.py
+++ b/backend.py
@@ -1,6 +1,7 @@
-import sys;
-import math;
-import equivCheck;
+import sys
+import math
+import equivCheck
+import convert
 
 class RegularExpressionTreeNode():
     #Constructor For RegularExpressionTreeNode:
@@ -558,7 +559,10 @@ class KarnaughMap():
         expression = self.getExpressionFromGroupings()
         return True, expression
 
-def main(inputValue): 
+def main(statement): 
+    # Process the statement the user inputted
+    inputValue = convert.main(statement)
+
     countLines = 0;
     allKarnaughMaps = []; 
     #Invoke Conversion to CDNF Form:
@@ -584,7 +588,7 @@ def main(inputValue):
     print("Done w/ Karnaugh Map.");
     countLines += 1;
     allKarnaughMaps.append(currentKMap);
-    return allKarnaughMaps[0], variables, outputFromHLDEquiv[5]
+    return allKarnaughMaps[0], variables, statement # outputFromHLDEquiv[5]
 
 if __name__ == '__main__':
     if(len(sys.argv) >= 2):     

--- a/convert.py
+++ b/convert.py
@@ -161,15 +161,24 @@ def infixToPostfix(infix):
 
 #Convert Infix Notation STR To Prefix Notation STR:
 def convertInfixToPrefix(infix):
+	infix = infix.replace(" ", "")	
+	infix = formatSpecialOperators(infix)
 	infix = infix[::-1]
+	print(infix)
 	for k in range(0, len(infix)):
 		if(infix[k] == '('):
 			infix = infix[:k] + ')' + infix[k+1:]
 		elif(infix[k] == ')'):
-			infix = infix[:k] + '(' + infix[k+1:]			
-	prefix = infixToPostfix(infix.replace(" ", "")) 
+			infix = infix[:k] + '(' + infix[k+1:]		
+	prefix = infixToPostfix(infix) 
 	prefix = prefix[::-1]
 	return prefix
+
+#Formatting For Biconditional/Conditional Operators:
+def formatSpecialOperators(infix):
+	infix = infix.replace("<->", "=")
+	infix = infix.replace("->", ">")
+	return infix
 
 #Convert To Tree:
 def convertToTree(postfix):
@@ -227,7 +236,6 @@ def main(inputValue):
 	finalExpression = currentRoot.convertToHLD()
 	print(finalExpression)
 	return finalExpression
-
 
 if __name__ == '__main__':
 	if(len(sys.argv) >= 2):     

--- a/convert.py
+++ b/convert.py
@@ -219,9 +219,15 @@ def convertToTree(postfix):
 	return convertToTree.peek()
 
 #Main Driver Code:
-currentExpression = str(sys.argv[1])
-prefixValue = convertInfixToPrefix(currentExpression)
-print("Prefix Expression:", prefixValue)
-currentRoot = convertToTree(prefixValue[::-1])
-print(currentRoot.convertToHLD())
+def main(inputValue):
+	currentExpression = str(sys.argv[1])
+	prefixValue = convertInfixToPrefix(currentExpression)
+	print("Prefix Expression:", prefixValue)
+	currentRoot = convertToTree(prefixValue[::-1])
+	print(currentRoot.convertToHLD())
 
+
+if __name__ == '__main__':
+	if(len(sys.argv) >= 2):     
+		inputValue = str(sys.argv[1])
+		main(inputValue)

--- a/convert.py
+++ b/convert.py
@@ -166,10 +166,11 @@ def convertPrefixToTree(prefix):
 		elif(isOperator(prefix[k]) and prefix[k] == "~"):
 			prevOne = None
 			if(not(convertToTree.isEmpty())):
-				prevOne = convertToTree.top()
+				prevOne = convertToTree.peek()
 				convertToTree.pop()
 			currentNode = TreeNode(prefix[k])
 			currentNode.left = prevOne 
+			convertToTree.push(currentNode)
 		else:
 			currentNode = TreeNode(prefix[k])
 			convertToTree.push(currentNode)

--- a/convert.py
+++ b/convert.py
@@ -1,4 +1,3 @@
-
 '''
 Takes An Expression From Infix Notation To Prefix Notation.
 For example, it will take: 
@@ -8,22 +7,33 @@ For example, it will take:
 import sys
 from pythonds.basic import Stack	
 
+#Basic Tree Structure For Expression:
+#Run w/ Basic Command 
 class TreeNode(object):
 	"""docstring for TreeNode"""
 	def __init__(self, value):
+		#Store Node Value + Left + Right Pointers.
 		self.value = value
 		self.left = None
 		self.right = None 
 
-	def print(self):
-		if(self.left != None):
-			self.left.print()
-		if(self.right != None):
-			self.right.print()
+	#Basic Helper Function To Print Subtree Rooted At self.
+	def printTree(self):
+		if(self == None):
+			return;
+		print(self.value)
+		self.left.print()
+		self.right.print()
 
 	def convertToHLD(self):
+		#Base Case:
+		if(self == None):
+			return "";
+		#Initialize Current Output Expression:
 		output = "";
+		#Case 1: Operator.
 		if(isOperator(self.value)):
+			#Respective STR Based On Operator.
 			if(self.value == '&'):
 				output += "and("
 			elif(self.value == '|'):
@@ -35,19 +45,21 @@ class TreeNode(object):
 			elif(self.value == '~'):
 				output += "not("
 			
+			#Negation Does Not Have Left Value.
+			#By Definition/Construction of Expression Tree, 
+			#Negation Nodes Only Have Left Children.
 			if(self.value != "~"):
-				if(self.right != None):
-					output += self.right.convertToHLD()
-			if(self.left != None):
-				if(self.value != "~"):
-					output += ", ";
-				output += self.left.convertToHLD()
+				output += self.right.convertToHLD()
+			if(self.value != "~"):
+				output += ", ";
+			output += self.left.convertToHLD()
 			output += ")"
 		else:
+			#Should Be Alpha Atomic Statement/Variable.
 			output += self.value
 		return output
 
-
+#Obtain Associativity of Operator.
 def getAssociativity(c):	
 	if(c == '&'):
 		return 'L'
@@ -62,7 +74,10 @@ def getAssociativity(c):
 	else:
 		return 'L'
    
+#Used By infixToPostfix().
+#Determines if c is Valid Operator.
 def isOperator(c):
+	#All Boolean Logic Operators.
 	if(c == '&'):
 		return True
 	elif(c == '|'):
@@ -73,10 +88,14 @@ def isOperator(c):
 		return True
 	elif(c == '~'):
 		return True
+	#Default Case: 
 	else:
 		return False
 
+#Used By infixToPostfix().
+#Determines Precedence of c.
 def getPrecedence(c):
+	#Respective Operator Precedence.
 	if(c == '&'):
 		return 2
 	elif(c == '|'):
@@ -87,16 +106,20 @@ def getPrecedence(c):
 		return 0
 	elif(c == '~'):
 		return 4
+	#Default Case:
 	else:
 		return -1
 
+#Run Shunting-Yard Algorithm By Edgar Dijkstra.
 def infixToPostfix(infix):
-	infix = '(' + infix + ')'  
+	#infix = '(' + infix + ')'  
+	#Initialize Stack.
 	opStack = Stack() 
 	output = ""
-	print(infix)
-	for k in range(0, len(infix)):
-		token = infix[k]
+	#print(infix)
+	#Loop Through All Tokens:
+	for token in infix:
+		#Case 1: Operator.
 		if(isOperator(token)):
 			while(not(opStack.isEmpty())
 				and isOperator(opStack.peek())
@@ -105,12 +128,15 @@ def infixToPostfix(infix):
 				output += opStack.peek()
 				opStack.pop()
 			opStack.push(token)   
+		#Case 2: Left Paranthesis.
 		elif(token == '('):
 			opStack.push(token)
+		#Case 3: Right Paranthesis.
 		elif(token == ')'):
 			while(not(opStack.isEmpty()) and opStack.peek() != '('):
 				output += opStack.peek()
 				opStack.pop()
+			#Error-Checking:
 			if(opStack.isEmpty()):
 				print("Empty Stack.")
 				print(output)
@@ -118,19 +144,22 @@ def infixToPostfix(infix):
 			if(opStack.peek() == '('):
 				opStack.pop()
 		else:
-			if(not(token.isalpha()) and not(token.isspace())):
+			#Check For Non-Alpha Characters:
+			if(not(token.isalpha())):
 				print("Not Alpha Not Space.")
 				return "ERROR"
 			output += token
-
+	#Append All Remaining Characters From opStack.
 	while(not(opStack.isEmpty())):
 		if(opStack.peek() == '(' or opStack.peek() == ')'):
-			print("Uh-OH!")
+			print("Uh-OH! Mismatched Paranthesis")
 			return "ERROR"
 		output += opStack.peek()
 		opStack.pop()
+	#Return Output.
 	return output
 
+#Convert Infix Notation STR To Prefix Notation STR:
 def convertInfixToPrefix(infix):
 	infix = infix[::-1]
 	for k in range(0, len(infix)):
@@ -142,48 +171,57 @@ def convertInfixToPrefix(infix):
 	prefix = prefix[::-1]
 	return prefix
 
-def convertPrefixToTree(prefix):
-	if(prefix == "ERROR"):
+#Convert To Tree:
+def convertToTree(postfix):
+	#If Output convertInfixToPrefix Returned "ERROR" + Postfix = "RORRE".
+	if(postfix == "RORRE"):
 		return
+	#Initialize Stack.
 	convertToTree = Stack()
-	for k in range(0, len(prefix)):
-		if(isOperator(prefix[k]) and prefix[k] != "~"):
+	for k in range(0, len(postfix)):
+		#Case 1: Operator + Not-Negation
+		if(isOperator(postfix[k]) and postfix[k] != "~"):
+			#Pop Previous One TreeNode.
 			prevOne = None
 			if(not(convertToTree.isEmpty())):
 				prevOne = convertToTree.peek()
 				convertToTree.pop()
-			
+			#Pop Previous Two TreeNode.
 			prevTwo = None
 			if(not(convertToTree.isEmpty())):
 				prevTwo = convertToTree.peek()
 				convertToTree.pop()
-
-			currentNode = TreeNode(prefix[k])
+			#Create + Set New TreeNode.
+			currentNode = TreeNode(postfix[k])
 			currentNode.left = prevTwo
 			currentNode.right = prevOne
 			convertToTree.push(currentNode)
-
-		elif(isOperator(prefix[k]) and prefix[k] == "~"):
+		#Case 2: Operator + Negation.
+		elif(isOperator(postfix[k]) and postfix[k] == "~"):
+			#Pop Previous One TreeNode.
 			prevOne = None
 			if(not(convertToTree.isEmpty())):
 				prevOne = convertToTree.peek()
 				convertToTree.pop()
-			currentNode = TreeNode(prefix[k])
+			#Create + Set New TreeNode.
+			currentNode = TreeNode(postfix[k])
 			currentNode.left = prevOne 
 			convertToTree.push(currentNode)
+		#Case 3: New Leaf Node.
 		else:
-			currentNode = TreeNode(prefix[k])
+			currentNode = TreeNode(postfix[k])
 			convertToTree.push(currentNode)
 
+	#Assert Only Root:
 	if(convertToTree.size() != 1):
 		print("Error In Construction. Must Review Input/Output.")
 	#Set New Head Value = Top/Root of Stack.
 	return convertToTree.peek()
 
+#Main Driver Code:
 currentExpression = str(sys.argv[1])
 prefixValue = convertInfixToPrefix(currentExpression)
-print(prefixValue)
-root = convertPrefixToTree(prefixValue[::-1])
-#root.print()
-print(root.convertToHLD())
+print("Prefix Expression:", prefixValue)
+currentRoot = convertToTree(prefixValue[::-1])
+print(currentRoot.convertToHLD())
 

--- a/convert.py
+++ b/convert.py
@@ -1,0 +1,188 @@
+
+'''
+Takes An Expression From Infix Notation To Prefix Notation.
+For example, it will take: 
+(A & B) => and(A, B)
+'''
+
+import sys
+from pythonds.basic import Stack	
+
+class TreeNode(object):
+	"""docstring for TreeNode"""
+	def __init__(self, value):
+		self.value = value
+		self.left = None
+		self.right = None 
+
+	def print(self):
+		if(self.left != None):
+			self.left.print()
+		if(self.right != None):
+			self.right.print()
+
+	def convertToHLD(self):
+		output = "";
+		if(isOperator(self.value)):
+			if(self.value == '&'):
+				output += "and("
+			elif(self.value == '|'):
+				output += "or("
+			elif(self.value == '='):
+				output += "iff("
+			elif(self.value == '>'):
+				output += "if("
+			elif(self.value == '~'):
+				output += "not("
+			
+			if(self.value != "~"):
+				if(self.right != None):
+					output += self.right.convertToHLD()
+			if(self.left != None):
+				if(self.value != "~"):
+					output += ", ";
+				output += self.left.convertToHLD()
+			output += ")"
+		else:
+			output += self.value
+		return output
+
+
+def getAssociativity(c):	
+	if(c == '&'):
+		return 'L'
+	elif(c == '|'):
+		return 'L'
+	elif(c == '='):
+		return 'L'
+	elif(c == '>'):
+		return 'L'
+	elif(c == '~'):
+		return 'R'
+	else:
+		return 'L'
+   
+def isOperator(c):
+	if(c == '&'):
+		return True
+	elif(c == '|'):
+		return True
+	elif(c == '='):
+		return True
+	elif(c == '>'):
+		return True
+	elif(c == '~'):
+		return True
+	else:
+		return False
+
+def getPrecedence(c):
+	if(c == '&'):
+		return 2
+	elif(c == '|'):
+		return 1
+	elif(c == '='):
+		return 0
+	elif(c == '>'):
+		return 0
+	elif(c == '~'):
+		return 4
+	else:
+		return -1
+
+def infixToPostfix(infix):
+	infix = '(' + infix + ')'  
+	opStack = Stack() 
+	output = ""
+	print(infix)
+	for k in range(0, len(infix)):
+		token = infix[k]
+		if(isOperator(token)):
+			while(not(opStack.isEmpty())
+				and isOperator(opStack.peek())
+				and ((getAssociativity(token) == 'L' and getPrecedence(opStack.peek()) >= getPrecedence(token))
+					or (getAssociativity(token) ==  'R' and getPrecedence(opStack.peek()) > getPrecedence(token)))):
+				output += opStack.peek()
+				opStack.pop()
+			opStack.push(token)   
+		elif(token == '('):
+			opStack.push(token)
+		elif(token == ')'):
+			while(not(opStack.isEmpty()) and opStack.peek() != '('):
+				output += opStack.peek()
+				opStack.pop()
+			if(opStack.isEmpty()):
+				print("Empty Stack.")
+				print(output)
+				return "ERROR"
+			if(opStack.peek() == '('):
+				opStack.pop()
+		else:
+			if(not(token.isalpha()) and not(token.isspace())):
+				print("Not Alpha Not Space.")
+				return "ERROR"
+			output += token
+
+	while(not(opStack.isEmpty())):
+		if(opStack.peek() == '(' or opStack.peek() == ')'):
+			print("Uh-OH!")
+			return "ERROR"
+		output += opStack.peek()
+		opStack.pop()
+	return output
+
+def convertInfixToPrefix(infix):
+	infix = infix[::-1]
+	for k in range(0, len(infix)):
+		if(infix[k] == '('):
+			infix = infix[:k] + ')' + infix[k+1:]
+		elif(infix[k] == ')'):
+			infix = infix[:k] + '(' + infix[k+1:]			
+	prefix = infixToPostfix(infix.replace(" ", "")) 
+	prefix = prefix[::-1]
+	return prefix
+
+def convertPrefixToTree(prefix):
+	if(prefix == "ERROR"):
+		return
+	convertToTree = Stack()
+	for k in range(0, len(prefix)):
+		if(isOperator(prefix[k]) and prefix[k] != "~"):
+			prevOne = None
+			if(not(convertToTree.isEmpty())):
+				prevOne = convertToTree.peek()
+				convertToTree.pop()
+			
+			prevTwo = None
+			if(not(convertToTree.isEmpty())):
+				prevTwo = convertToTree.peek()
+				convertToTree.pop()
+
+			currentNode = TreeNode(prefix[k])
+			currentNode.left = prevTwo
+			currentNode.right = prevOne
+			convertToTree.push(currentNode)
+
+		elif(isOperator(prefix[k]) and prefix[k] == "~"):
+			prevOne = None
+			if(not(convertToTree.isEmpty())):
+				prevOne = convertToTree.top()
+				convertToTree.pop()
+			currentNode = TreeNode(prefix[k])
+			currentNode.left = prevOne 
+		else:
+			currentNode = TreeNode(prefix[k])
+			convertToTree.push(currentNode)
+
+	if(convertToTree.size() != 1):
+		print("Error In Construction. Must Review Input/Output.")
+	#Set New Head Value = Top/Root of Stack.
+	return convertToTree.peek()
+
+currentExpression = str(sys.argv[1])
+prefixValue = convertInfixToPrefix(currentExpression)
+print(prefixValue)
+root = convertPrefixToTree(prefixValue[::-1])
+#root.print()
+print(root.convertToHLD())
+

--- a/convert.py
+++ b/convert.py
@@ -20,7 +20,7 @@ class TreeNode(object):
 	#Basic Helper Function To Print Subtree Rooted At self.
 	def printTree(self):
 		if(self == None):
-			return;
+			return
 		print(self.value)
 		self.left.print()
 		self.right.print()
@@ -28,9 +28,9 @@ class TreeNode(object):
 	def convertToHLD(self):
 		#Base Case:
 		if(self == None):
-			return "";
+			return ""
 		#Initialize Current Output Expression:
-		output = "";
+		output = ""
 		#Case 1: Operator.
 		if(isOperator(self.value)):
 			#Respective STR Based On Operator.
@@ -51,7 +51,7 @@ class TreeNode(object):
 			if(self.value != "~"):
 				output += self.right.convertToHLD()
 			if(self.value != "~"):
-				output += ", ";
+				output += ", "
 			output += self.left.convertToHLD()
 			output += ")"
 		else:
@@ -220,11 +220,13 @@ def convertToTree(postfix):
 
 #Main Driver Code:
 def main(inputValue):
-	currentExpression = str(sys.argv[1])
+	currentExpression = inputValue
 	prefixValue = convertInfixToPrefix(currentExpression)
 	print("Prefix Expression:", prefixValue)
 	currentRoot = convertToTree(prefixValue[::-1])
-	print(currentRoot.convertToHLD())
+	finalExpression = currentRoot.convertToHLD()
+	print(finalExpression)
+	return finalExpression
 
 
 if __name__ == '__main__':

--- a/frontend.pyw
+++ b/frontend.pyw
@@ -9,7 +9,7 @@ from functools import partial
 from traceback import format_exc
 import tkinter.simpledialog
 import pickle
-import convert
+
 
 #Function For Changing Text in Statusbar (Bottom of Program)
 #Arguments: x = New Text To Put In Statusbar.
@@ -190,9 +190,7 @@ All operators are either unary (not) or binary (and, or, if, iff), and there is 
 ''', parent=root, initialvalue="open")
 
 if statement != "open":
-    # Process the statement the user inputted
-    convertStatement = convert.main(statement)
-    currentKMap, variables, original = backend.main(convertStatement)
+    currentKMap, variables, original = backend.main(statement)
 else:
     # Load K-Map from file. The K-Map is serialized as a python object into a file in the form of a pickle.
     filename = askopenfilename(filetypes=(("K-Map Files", ".kmap"),), defaultextension=".kmap")

--- a/frontend.pyw
+++ b/frontend.pyw
@@ -9,6 +9,7 @@ from functools import partial
 from traceback import format_exc
 import tkinter.simpledialog
 import pickle
+import convert
 
 #Function For Changing Text in Statusbar (Bottom of Program)
 #Arguments: x = New Text To Put In Statusbar.
@@ -190,7 +191,8 @@ All operators are either unary (not) or binary (and, or, if, iff), and there is 
 
 if statement != "open":
     # Process the statement the user inputted
-    currentKMap, variables, original = backend.main(statement)
+    convertStatement = convert.main(statement)
+    currentKMap, variables, original = backend.main(convertStatement)
 else:
     # Load K-Map from file. The K-Map is serialized as a python object into a file in the form of a pickle.
     filename = askopenfilename(filetypes=(("K-Map Files", ".kmap"),), defaultextension=".kmap")


### PR DESCRIPTION
Hello Team.
This Pull Request is so that Clients on the Frontend Side can enter the expression as they normally do in Propositional Logic/Boolean Algebra and our Software can still make use of HLDEquivalency in the same manner (i.e., by converting the Infix Notation Expression Into Prefix Notation Effectively). 
Below is an example of this idea.
Input Supplied By Client: ~A -> ~B 
Input Required By HLD/Converted By convert.py: if(not(A), not(B)).
Hope you all can review the functionality of this so we can continue progressing!

Best Regards,
Venkat Srinivas